### PR TITLE
Renamed 'is' and 'isNot' to 'mustBe' and 'mustNotBe' to avoid the nee…

### DIFF
--- a/lib/src/main/kotlin/io/github/ccjhr/any/AnyAssertionAdjective.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/any/AnyAssertionAdjective.kt
@@ -3,14 +3,14 @@ package io.github.ccjhr.any
 /**
  * Adjectives that are expected to apply to any object.
  * @since 1.0.0
- * @see is
- * @see isNot
+ * @see mustBe
+ * @see mustNotBe
  */
 enum class AnyAssertionAdjective {
     /**
      * @since 1.0.0
-     * @sample io.github.ccjhr.samples.any.isNull
-     * @sample io.github.ccjhr.samples.any.isNotNull
+     * @sample io.github.ccjhr.samples.any.mustBeNull
+     * @sample io.github.ccjhr.samples.any.mustNotBeNull
      */
     Null
 }

--- a/lib/src/main/kotlin/io/github/ccjhr/any/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/any/MustBe.kt
@@ -6,14 +6,14 @@ import kotlin.test.fail
 
 /**
  * Verifies that the object under test applies to a given [AnyAssertionAdjective].
- * @since 1.0.0
+ * @since 4.0.0
  * @param adjective The [AnyAssertionAdjective] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable object.
- * @see isNot
- * @sample io.github.ccjhr.samples.any.isNull
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.any.mustBeNull
  */
-inline infix fun <reified T> AssertionContext<T>.`is`(adjective: AnyAssertionAdjective) {
+inline infix fun <reified T> AssertionContext<T>.mustBe(adjective: AnyAssertionAdjective) {
     when (adjective) {
         Null -> if (this.content != null) fail("Expecting object to be null, but it's not.")
     }

--- a/lib/src/main/kotlin/io/github/ccjhr/any/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/any/MustNotBe.kt
@@ -6,14 +6,14 @@ import kotlin.test.fail
 
 /**
  * Verifies that the object under test does not apply to a given [AnyAssertionAdjective].
- * @since 1.0.0
+ * @since 4.0.0
  * @param adjective The [AnyAssertionAdjective] that does not apply to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable object.
- * @see is
- * @sample io.github.ccjhr.samples.any.isNotNull
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.any.mustNotBeNull
  */
-inline infix fun <reified T> AssertionContext<T>.isNot(adjective: AnyAssertionAdjective) {
+inline infix fun <reified T> AssertionContext<T>.mustNotBe(adjective: AnyAssertionAdjective) {
     when (adjective) {
         Null -> if (this.content == null) fail("Expecting object not to be null, but it is.")
     }

--- a/lib/src/main/kotlin/io/github/ccjhr/boolean/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/boolean/MustBe.kt
@@ -7,15 +7,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the object under test matches a given [Boolean] value.
- * @since 2.0.0
+ * @since 4.0.0
  * @param value A [Boolean] value that matches the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Boolean].
- * @see isNot
- * @sample io.github.ccjhr.samples.boolean.isTrue
- * @sample io.github.ccjhr.samples.boolean.isFalse
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.boolean.mustBeTrue
+ * @sample io.github.ccjhr.samples.boolean.mustBeFalse
  */
-inline infix fun <reified T : Boolean?> AssertionContext<T>.`is`(value: Boolean) {
+inline infix fun <reified T : Boolean?> AssertionContext<T>.mustBe(value: Boolean) {
     expectNotNull(this.content)
 
     if (this.content != value) {

--- a/lib/src/main/kotlin/io/github/ccjhr/boolean/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/boolean/MustNotBe.kt
@@ -6,15 +6,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the object under test doesn't match a given [Boolean] value.
- * @since 2.0.0
+ * @since 4.0.0
  * @param value A [Boolean] value that doesn't match the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Boolean].
- * @see is
- * @sample io.github.ccjhr.samples.boolean.isNotTrue
- * @sample io.github.ccjhr.samples.boolean.isNotFalse
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.boolean.mustNotBeTrue
+ * @sample io.github.ccjhr.samples.boolean.mustNotBeFalse
  */
-inline infix fun <reified T : Boolean?> AssertionContext<T>.isNot(value: Boolean) {
+inline infix fun <reified T : Boolean?> AssertionContext<T>.mustNotBe(value: Boolean) {
     expectNotNull(this.content)
 
     if (this.content == value) {

--- a/lib/src/main/kotlin/io/github/ccjhr/charsequence/CharSequenceAssertionAdjective.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/charsequence/CharSequenceAssertionAdjective.kt
@@ -3,8 +3,8 @@ package io.github.ccjhr.charsequence
 /**
  * Adjectives that are expected to apply to a [CharSequence].
  * @since 1.0.0
- * @see is
- * @see isNot
+ * @see mustBe
+ * @see mustNotBe
  */
 enum class CharSequenceAssertionAdjective {
     /**

--- a/lib/src/main/kotlin/io/github/ccjhr/charsequence/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/charsequence/MustBe.kt
@@ -8,15 +8,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [CharSequence] under test applies to a given [CharSequenceAssertionAdjective].
- * @since 1.0.0
+ * @since 4.0.0
  * @param adjective The [CharSequenceAssertionAdjective] that applies to the [CharSequence] under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [CharSequence].
- * @see isNot
- * @sample io.github.ccjhr.samples.charsequence.isBlank
- * @sample io.github.ccjhr.samples.charsequence.isEmpty
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.charsequence.mustBeBlank
+ * @sample io.github.ccjhr.samples.charsequence.mustBeEmpty
  */
-inline infix fun <reified T : CharSequence?> AssertionContext<T>.`is`(adjective: CharSequenceAssertionAdjective) {
+inline infix fun <reified T : CharSequence?> AssertionContext<T>.mustBe(adjective: CharSequenceAssertionAdjective) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/charsequence/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/charsequence/MustNotBe.kt
@@ -7,15 +7,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [CharSequence] under test does not apply to a given [CharSequenceAssertionAdjective].
- * @since 1.0.0
+ * @since 4.0.0
  * @param adjective The [CharSequenceAssertionAdjective] that does not apply to the [CharSequence] under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [CharSequence].
- * @see is
- * @sample io.github.ccjhr.samples.charsequence.isNotBlank
- * @sample io.github.ccjhr.samples.charsequence.isNotEmpty
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.charsequence.mustNotBeBlank
+ * @sample io.github.ccjhr.samples.charsequence.mustNotBeEmpty
  */
-inline infix fun <reified T : CharSequence?> AssertionContext<T>.isNot(adjective: CharSequenceAssertionAdjective) {
+inline infix fun <reified T : CharSequence?> AssertionContext<T>.mustNotBe(adjective: CharSequenceAssertionAdjective) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/collection/CollectionAssertionAdjective.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/collection/CollectionAssertionAdjective.kt
@@ -1,19 +1,19 @@
 package io.github.ccjhr.collection
 
-import io.github.ccjhr.charsequence.`is`
-import io.github.ccjhr.charsequence.isNot
+import io.github.ccjhr.charsequence.mustBe
+import io.github.ccjhr.charsequence.mustNotBe
 
 /**
  * Adjectives that are expected to apply to a [Collection].
  * @since 2.0.0
- * @see is
- * @see isNot
+ * @see mustBe
+ * @see mustNotBe
  */
 enum class CollectionAssertionAdjective {
     /**
      * @since 2.0.0
-     * @sample io.github.ccjhr.samples.collection.isEmpty
-     * @sample io.github.ccjhr.samples.collection.isNotEmpty
+     * @sample io.github.ccjhr.samples.collection.mustBeEmpty
+     * @sample io.github.ccjhr.samples.collection.mustNotBeEmpty
      */
     Empty,
 }

--- a/lib/src/main/kotlin/io/github/ccjhr/collection/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/collection/MustBe.kt
@@ -1,21 +1,21 @@
 package io.github.ccjhr.collection
 
 import io.github.ccjhr.AssertionContext
-import io.github.ccjhr.charsequence.isNot
+import io.github.ccjhr.charsequence.mustNotBe
 import io.github.ccjhr.collection.CollectionAssertionAdjective.*
 import io.github.ccjhr.expectNotNull
 import kotlin.test.fail
 
 /**
  * Verifies that the [Collection] under test applies to a given [CollectionAssertionAdjective].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [CollectionAssertionAdjective] that applies to the [Collection] under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Collection] containing any nullable or non-nullable type.
- * @see isNot
- * @sample io.github.ccjhr.samples.collection.isEmpty
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.collection.mustBeEmpty
  */
-inline infix fun <reified T> AssertionContext<out Collection<T>?>.`is`(adjective: CollectionAssertionAdjective) {
+inline infix fun <reified T> AssertionContext<out Collection<T>?>.mustBe(adjective: CollectionAssertionAdjective) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/collection/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/collection/MustNotBe.kt
@@ -7,14 +7,14 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Collection] under test doesn't apply to a given [CollectionAssertionAdjective].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [CollectionAssertionAdjective] that applies to the [Collection] under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Collection] containing any nullable or non-nullable type.
- * @see is
- * @sample io.github.ccjhr.samples.collection.isNotEmpty
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.collection.mustNotBeEmpty
  */
-inline infix fun <reified T> AssertionContext<out Collection<T>?>.isNot(adjective: CollectionAssertionAdjective) {
+inline infix fun <reified T> AssertionContext<out Collection<T>?>.mustNotBe(adjective: CollectionAssertionAdjective) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/NumberAssertionAdjectives.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/NumberAssertionAdjectives.kt
@@ -3,75 +3,75 @@ package io.github.ccjhr.number
 /**
  * Adjectives that are expected to apply to any signed number.
  * @since 2.0.0
- * @see io.github.ccjhr.number.double.is
- * @see io.github.ccjhr.number.double.isNot
- * @see io.github.ccjhr.number.float.is
- * @see io.github.ccjhr.number.float.isNot
- * @see io.github.ccjhr.number.int.is
- * @see io.github.ccjhr.number.int.isNot
- * @see io.github.ccjhr.number.long.is
- * @see io.github.ccjhr.number.long.isNot
- * @see io.github.ccjhr.number.short.is
- * @see io.github.ccjhr.number.short.isNot
+ * @see io.github.ccjhr.number.double.mustBe
+ * @see io.github.ccjhr.number.double.mustNotBe
+ * @see io.github.ccjhr.number.float.mustBe
+ * @see io.github.ccjhr.number.float.mustNotBe
+ * @see io.github.ccjhr.number.int.mustBe
+ * @see io.github.ccjhr.number.int.mustNotBe
+ * @see io.github.ccjhr.number.long.mustBe
+ * @see io.github.ccjhr.number.long.mustNotBe
+ * @see io.github.ccjhr.number.short.mustBe
+ * @see io.github.ccjhr.number.short.mustNotBe
  */
 enum class NumberAssertionAdjectives {
     /**
      * @since 1.0.0
-     * @sample io.github.ccjhr.samples.number.double.isOdd
-     * @sample io.github.ccjhr.samples.number.double.isNotOdd
-     * @sample io.github.ccjhr.samples.number.float.isOdd
-     * @sample io.github.ccjhr.samples.number.float.isNotOdd
-     * @sample io.github.ccjhr.samples.number.int.isOdd
-     * @sample io.github.ccjhr.samples.number.int.isNotOdd
-     * @sample io.github.ccjhr.samples.number.long.isOdd
-     * @sample io.github.ccjhr.samples.number.long.isNotOdd
-     * @sample io.github.ccjhr.samples.number.short.isOdd
-     * @sample io.github.ccjhr.samples.number.short.isNotOdd
+     * @sample io.github.ccjhr.samples.number.double.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.double.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.float.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.float.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.int.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.int.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.long.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.long.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.short.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.short.mustNotBeOdd
      */
     Odd,
 
     /**
      * @since 1.0.0
-     * @sample io.github.ccjhr.samples.number.double.isEven
-     * @sample io.github.ccjhr.samples.number.double.isNotEven
-     * @sample io.github.ccjhr.samples.number.float.isEven
-     * @sample io.github.ccjhr.samples.number.float.isNotEven
-     * @sample io.github.ccjhr.samples.number.int.isEven
-     * @sample io.github.ccjhr.samples.number.int.isNotEven
-     * @sample io.github.ccjhr.samples.number.long.isEven
-     * @sample io.github.ccjhr.samples.number.long.isNotEven
-     * @sample io.github.ccjhr.samples.number.short.isEven
-     * @sample io.github.ccjhr.samples.number.short.isNotEven
+     * @sample io.github.ccjhr.samples.number.double.mustBeEven
+     * @sample io.github.ccjhr.samples.number.double.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.float.mustBeEven
+     * @sample io.github.ccjhr.samples.number.float.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.int.mustBeEven
+     * @sample io.github.ccjhr.samples.number.int.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.long.mustBeEven
+     * @sample io.github.ccjhr.samples.number.long.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.short.mustBeEven
+     * @sample io.github.ccjhr.samples.number.short.mustNotBeEven
      */
     Even,
 
     /**
      * @since 2.0.0
-     * @sample io.github.ccjhr.samples.number.double.isPositive
-     * @sample io.github.ccjhr.samples.number.double.isNotPositive
-     * @sample io.github.ccjhr.samples.number.float.isPositive
-     * @sample io.github.ccjhr.samples.number.float.isNotPositive
-     * @sample io.github.ccjhr.samples.number.int.isPositive
-     * @sample io.github.ccjhr.samples.number.int.isNotPositive
-     * @sample io.github.ccjhr.samples.number.long.isPositive
-     * @sample io.github.ccjhr.samples.number.long.isNotPositive
-     * @sample io.github.ccjhr.samples.number.short.isPositive
-     * @sample io.github.ccjhr.samples.number.short.isNotPositive
+     * @sample io.github.ccjhr.samples.number.double.mustBePositive
+     * @sample io.github.ccjhr.samples.number.double.mustNotBePositive
+     * @sample io.github.ccjhr.samples.number.float.mustBePositive
+     * @sample io.github.ccjhr.samples.number.float.mustNotBePositive
+     * @sample io.github.ccjhr.samples.number.int.mustBePositive
+     * @sample io.github.ccjhr.samples.number.int.mustNotBePositive
+     * @sample io.github.ccjhr.samples.number.long.mustBePositive
+     * @sample io.github.ccjhr.samples.number.long.mustNotBePositive
+     * @sample io.github.ccjhr.samples.number.short.mustBePositive
+     * @sample io.github.ccjhr.samples.number.short.mustNotBePositive
      */
     Positive,
 
     /**
      * @since 2.0.0
-     * @sample io.github.ccjhr.samples.number.double.isNegative
-     * @sample io.github.ccjhr.samples.number.double.isNotNegative
-     * @sample io.github.ccjhr.samples.number.float.isNegative
-     * @sample io.github.ccjhr.samples.number.float.isNotNegative
-     * @sample io.github.ccjhr.samples.number.int.isNegative
-     * @sample io.github.ccjhr.samples.number.int.isNotNegative
-     * @sample io.github.ccjhr.samples.number.long.isNegative
-     * @sample io.github.ccjhr.samples.number.long.isNotNegative
-     * @sample io.github.ccjhr.samples.number.short.isNegative
-     * @sample io.github.ccjhr.samples.number.short.isNotNegative
+     * @sample io.github.ccjhr.samples.number.double.mustBeNegative
+     * @sample io.github.ccjhr.samples.number.double.mustNotBeNegative
+     * @sample io.github.ccjhr.samples.number.float.mustBeNegative
+     * @sample io.github.ccjhr.samples.number.float.mustNotBeNegative
+     * @sample io.github.ccjhr.samples.number.int.mustBeNegative
+     * @sample io.github.ccjhr.samples.number.int.mustNotBeNegative
+     * @sample io.github.ccjhr.samples.number.long.mustBeNegative
+     * @sample io.github.ccjhr.samples.number.long.mustNotBeNegative
+     * @sample io.github.ccjhr.samples.number.short.mustBeNegative
+     * @sample io.github.ccjhr.samples.number.short.mustNotBeNegative
      */
     Negative,
 }

--- a/lib/src/main/kotlin/io/github/ccjhr/number/UnsignedNumberAssertionAdjectives.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/UnsignedNumberAssertionAdjectives.kt
@@ -3,33 +3,33 @@ package io.github.ccjhr.number
 /**
  * Adjectives that are expected to apply to any unsigned number.
  * @since 2.0.0
- * @see io.github.ccjhr.number.uint.is
- * @see io.github.ccjhr.number.uint.isNot
- * @see io.github.ccjhr.number.ulong.is
- * @see io.github.ccjhr.number.ulong.isNot
- * @see io.github.ccjhr.number.ushort.is
- * @see io.github.ccjhr.number.ushort.isNot
+ * @see io.github.ccjhr.number.uint.mustBe
+ * @see io.github.ccjhr.number.uint.mustNotBe
+ * @see io.github.ccjhr.number.ulong.mustbe
+ * @see io.github.ccjhr.number.ulong.mustNotBe
+ * @see io.github.ccjhr.number.ushort.mustBe
+ * @see io.github.ccjhr.number.ushort.mustNotBe
  */
 enum class UnsignedNumberAssertionAdjectives {
     /**
      * @since 2.0.0
-     * @sample io.github.ccjhr.samples.number.uint.isOdd
-     * @sample io.github.ccjhr.samples.number.uint.isNotOdd
-     * @sample io.github.ccjhr.samples.number.ulong.isOdd
-     * @sample io.github.ccjhr.samples.number.ulong.isNotOdd
-     * @sample io.github.ccjhr.samples.number.ushort.isOdd
-     * @sample io.github.ccjhr.samples.number.ushort.isNotOdd
+     * @sample io.github.ccjhr.samples.number.uint.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.uint.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.ulong.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.ulong.mustNotBeOdd
+     * @sample io.github.ccjhr.samples.number.ushort.mustBeOdd
+     * @sample io.github.ccjhr.samples.number.ushort.mustNotBeOdd
      */
     Odd,
 
     /**
      * @since 2.0.0
-     * @sample io.github.ccjhr.samples.number.uint.isEven
-     * @sample io.github.ccjhr.samples.number.uint.isNotEven
-     * @sample io.github.ccjhr.samples.number.ulong.isEven
-     * @sample io.github.ccjhr.samples.number.ulong.isNotEven
-     * @sample io.github.ccjhr.samples.number.ushort.isEven
-     * @sample io.github.ccjhr.samples.number.ushort.isNotEven
+     * @sample io.github.ccjhr.samples.number.uint.mustBeEven
+     * @sample io.github.ccjhr.samples.number.uint.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.ulong.mustBeEven
+     * @sample io.github.ccjhr.samples.number.ulong.mustNotBeEven
+     * @sample io.github.ccjhr.samples.number.ushort.mustBeEven
+     * @sample io.github.ccjhr.samples.number.ushort.mustNotBeEven
      */
     Even,
 }

--- a/lib/src/main/kotlin/io/github/ccjhr/number/double/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/double/MustBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Double] under test applies to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Double].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.double.isOdd
- * @sample io.github.ccjhr.samples.number.double.isEven
- * @sample io.github.ccjhr.samples.number.double.isPositive
- * @sample io.github.ccjhr.samples.number.double.isNegative
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.double.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.double.mustBeEven
+ * @sample io.github.ccjhr.samples.number.double.mustBePositive
+ * @sample io.github.ccjhr.samples.number.double.mustBeNegative
  */
-inline infix fun <reified T : Double?> AssertionContext<T>.`is`(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Double?> AssertionContext<T>.mustBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/double/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/double/MustNotBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Double] under test does not apply to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Double].
- * @see is
- * @sample io.github.ccjhr.samples.number.double.isNotOdd
- * @sample io.github.ccjhr.samples.number.double.isNotEven
- * @sample io.github.ccjhr.samples.number.double.isPositive
- * @sample io.github.ccjhr.samples.number.double.isNegative
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.double.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.double.mustNotBeEven
+ * @sample io.github.ccjhr.samples.number.double.mustNotBePositive
+ * @sample io.github.ccjhr.samples.number.double.mustNotBeNegative
  */
-inline infix fun <reified T : Double?> AssertionContext<T>.isNot(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Double?> AssertionContext<T>.mustNotBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/float/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/float/MustBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Float] under test applies to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Float].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.float.isOdd
- * @sample io.github.ccjhr.samples.number.float.isEven
- * @sample io.github.ccjhr.samples.number.float.isPositive
- * @sample io.github.ccjhr.samples.number.float.isNegative
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.float.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.float.mustBeEven
+ * @sample io.github.ccjhr.samples.number.float.mustBePositive
+ * @sample io.github.ccjhr.samples.number.float.mustBeNegative
  */
-inline infix fun <reified T : Float?> AssertionContext<T>.`is`(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Float?> AssertionContext<T>.mustBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/float/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/float/MustNotBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Float] under test does not apply to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Float].
- * @see is
- * @sample io.github.ccjhr.samples.number.float.isNotOdd
- * @sample io.github.ccjhr.samples.number.float.isNotEven
- * @sample io.github.ccjhr.samples.number.float.isPositive
- * @sample io.github.ccjhr.samples.number.float.isNegative
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.float.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.float.mustNotBeEven
+ * @sample io.github.ccjhr.samples.number.float.mustNotBePositive
+ * @sample io.github.ccjhr.samples.number.float.mustNotBeNegative
  */
-inline infix fun <reified T : Float?> AssertionContext<T>.isNot(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Float?> AssertionContext<T>.mustNotBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/int/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/int/MustBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Int] under test applies to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Int].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.int.isOdd
- * @sample io.github.ccjhr.samples.number.int.isEven
- * @sample io.github.ccjhr.samples.number.int.isPositive
- * @sample io.github.ccjhr.samples.number.int.isNegative
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.int.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.int.mustBeEven
+ * @sample io.github.ccjhr.samples.number.int.mustBePositive
+ * @sample io.github.ccjhr.samples.number.int.mustBeNegative
  */
-inline infix fun <reified T: Int?> AssertionContext<T>.`is`(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T: Int?> AssertionContext<T>.mustBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when(adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/int/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/int/MustNotBe.kt
@@ -9,15 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Int] under test does not apply to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Int].
- * @see is
- * @sample io.github.ccjhr.samples.number.int.isNotOdd
- * @sample io.github.ccjhr.samples.number.int.isNotEven
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.int.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.int.mustNotBeEven
+ * @sample io.github.ccjhr.samples.number.int.mustNotBePositive
+ * @sample io.github.ccjhr.samples.number.int.mustNotBeNegative
  */
-inline infix fun <reified T : Int?> AssertionContext<T>.isNot(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Int?> AssertionContext<T>.mustNotBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/long/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/long/MustBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Long] under test applies to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Long].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.long.isOdd
- * @sample io.github.ccjhr.samples.number.long.isEven
- * @sample io.github.ccjhr.samples.number.long.isPositive
- * @sample io.github.ccjhr.samples.number.long.isNegative
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.long.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.long.mustBeEven
+ * @sample io.github.ccjhr.samples.number.long.mustBePositive
+ * @sample io.github.ccjhr.samples.number.long.mustBeNegative
  */
-inline infix fun <reified T : Long?> AssertionContext<T>.`is`(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Long?> AssertionContext<T>.mustBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/long/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/long/MustNotBe.kt
@@ -9,15 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Long] under test does not apply to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Long].
- * @see is
- * @sample io.github.ccjhr.samples.number.long.isNotOdd
- * @sample io.github.ccjhr.samples.number.long.isNotEven
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.long.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.long.mustNotBeEven
+ * @sample io.github.ccjhr.samples.number.long.mustNotBePositive
+ * @sample io.github.ccjhr.samples.number.long.mustNotBeNegative
  */
-inline infix fun <reified T : Long?> AssertionContext<T>.isNot(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Long?> AssertionContext<T>.mustNotBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/short/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/short/MustBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Short] under test applies to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Short].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.short.isOdd
- * @sample io.github.ccjhr.samples.number.short.isEven
- * @sample io.github.ccjhr.samples.number.short.isPositive
- * @sample io.github.ccjhr.samples.number.short.isNegative
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.short.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.short.mustBeEven
+ * @sample io.github.ccjhr.samples.number.short.mustBePositive
+ * @sample io.github.ccjhr.samples.number.short.mustBeNegative
  */
-inline infix fun <reified T: Short?> AssertionContext<T>.`is`(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T: Short?> AssertionContext<T>.mustBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when(adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/short/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/short/MustNotBe.kt
@@ -9,17 +9,17 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [Short] under test does not apply to a given [NumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [NumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [Short].
- * @see is
- * @sample io.github.ccjhr.samples.number.short.isNotOdd
- * @sample io.github.ccjhr.samples.number.short.isNotEven
- * @sample io.github.ccjhr.samples.number.short.isPositive
- * @sample io.github.ccjhr.samples.number.short.isNegative
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.short.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.short.mustNotBeEven
+ * @sample io.github.ccjhr.samples.number.short.mustNotBePositive
+ * @sample io.github.ccjhr.samples.number.short.mustNotBeNegative
  */
-inline infix fun <reified T : Short?> AssertionContext<T>.isNot(adjective: NumberAssertionAdjectives) {
+inline infix fun <reified T : Short?> AssertionContext<T>.mustNotBe(adjective: NumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/uint/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/uint/MustBe.kt
@@ -9,15 +9,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [UInt] under test applies to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [UInt].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.uint.isOdd
- * @sample io.github.ccjhr.samples.number.uint.isEven
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.uint.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.uint.mustBeEven
  */
-inline infix fun <reified T : UInt?> AssertionContext<T>.`is`(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : UInt?> AssertionContext<T>.mustBe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/uint/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/uint/MustNotBe.kt
@@ -10,15 +10,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [UInt] under test does not apply to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [UInt].
- * @see is
- * @sample io.github.ccjhr.samples.number.uint.isNotOdd
- * @sample io.github.ccjhr.samples.number.uint.isNotEven
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.uint.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.uint.mustNotBeEven
  */
-inline infix fun <reified T : UInt?> AssertionContext<T>.isNot(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : UInt?> AssertionContext<T>.mustNotBe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/ulong/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/ulong/MustBe.kt
@@ -10,15 +10,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [ULong] under test applies to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [ULong].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.ulong.isOdd
- * @sample io.github.ccjhr.samples.number.ulong.isEven
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.ulong.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.ulong.mustBeEven
  */
-inline infix fun <reified T : ULong?> AssertionContext<T>.`is`(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : ULong?> AssertionContext<T>.mustbe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/ulong/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/ulong/MustNotBe.kt
@@ -10,15 +10,15 @@ import kotlin.test.fail
 
 /**
  * Verifies that the [ULong] under test does not apply to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [ULong].
- * @see is
- * @sample io.github.ccjhr.samples.number.ulong.isNotOdd
- * @sample io.github.ccjhr.samples.number.ulong.isNotEven
+ * @see mustbe
+ * @sample io.github.ccjhr.samples.number.ulong.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.ulong.mustNotBeEven
  */
-inline infix fun <reified T : ULong?> AssertionContext<T>.isNot(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : ULong?> AssertionContext<T>.mustNotBe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {

--- a/lib/src/main/kotlin/io/github/ccjhr/number/ushort/MustBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/ushort/MustBe.kt
@@ -9,20 +9,20 @@ import io.github.ccjhr.number.UnsignedNumberAssertionAdjectives.Odd
 import kotlin.test.fail
 
 /**
- * Verifies that the [UShort] under test does not apply to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * Verifies that the [UShort] under test applies to a given [UnsignedNumberAssertionAdjectives].
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [UShort].
- * @see is
- * @sample io.github.ccjhr.samples.number.ushort.isNotOdd
- * @sample io.github.ccjhr.samples.number.ushort.isNotEven
+ * @see mustNotBe
+ * @sample io.github.ccjhr.samples.number.ushort.mustBeOdd
+ * @sample io.github.ccjhr.samples.number.ushort.mustBeEven
  */
-inline infix fun <reified T : UShort?> AssertionContext<T>.isNot(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : UShort?> AssertionContext<T>.mustBe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {
-        Odd -> if (this.content.mod(2.toUShort()) != 0.toUShort()) fail("Expecting <${this.content}> not to be odd, but it is.")
-        Even -> if (this.content.mod(2.toUShort()) == 0.toUShort()) fail("Expecting <${this.content}> not to be even, but it is.")
+        Odd -> if (this.content.mod(2.toUShort()) == 0.toUShort()) fail("Expecting <${this.content}> to be odd, but it's even.")
+        Even -> if (this.content.mod(2.toUShort()) != 0.toUShort()) fail("Expecting <${this.content}> to be even, but it's odd.")
     }
 }

--- a/lib/src/main/kotlin/io/github/ccjhr/number/ushort/MustNotBe.kt
+++ b/lib/src/main/kotlin/io/github/ccjhr/number/ushort/MustNotBe.kt
@@ -9,20 +9,20 @@ import io.github.ccjhr.number.UnsignedNumberAssertionAdjectives.Odd
 import kotlin.test.fail
 
 /**
- * Verifies that the [UShort] under test applies to a given [UnsignedNumberAssertionAdjectives].
- * @since 2.0.0
+ * Verifies that the [UShort] under test does not apply to a given [UnsignedNumberAssertionAdjectives].
+ * @since 4.0.0
  * @param adjective The [UnsignedNumberAssertionAdjectives] that applies to the object under test.
  * @throws AssertionError In case the assertion fails.
  * @receiver Any nullable or non-nullable [UShort].
- * @see isNot
- * @sample io.github.ccjhr.samples.number.ushort.isOdd
- * @sample io.github.ccjhr.samples.number.ushort.isEven
+ * @see mustBe
+ * @sample io.github.ccjhr.samples.number.ushort.mustNotBeOdd
+ * @sample io.github.ccjhr.samples.number.ushort.mustNotBeEven
  */
-inline infix fun <reified T : UShort?> AssertionContext<T>.`is`(adjective: UnsignedNumberAssertionAdjectives) {
+inline infix fun <reified T : UShort?> AssertionContext<T>.mustNotBe(adjective: UnsignedNumberAssertionAdjectives) {
     expectNotNull(this.content)
 
     when (adjective) {
-        Odd -> if (this.content.mod(2.toUShort()) == 0.toUShort()) fail("Expecting <${this.content}> to be odd, but it's even.")
-        Even -> if (this.content.mod(2.toUShort()) != 0.toUShort()) fail("Expecting <${this.content}> to be even, but it's odd.")
+        Odd -> if (this.content.mod(2.toUShort()) != 0.toUShort()) fail("Expecting <${this.content}> not to be odd, but it is.")
+        Even -> if (this.content.mod(2.toUShort()) == 0.toUShort()) fail("Expecting <${this.content}> not to be even, but it is.")
     }
 }

--- a/lib/src/samples/kotlin/AnySamples.kt
+++ b/lib/src/samples/kotlin/AnySamples.kt
@@ -1,22 +1,22 @@
 package io.github.ccjhr.samples.any
 
-fun isNull() {
+fun mustBeNull() {
     // given
     val obj: String? = null
 
     // then
     obj mustSatisfy {
-        it `is` Null
+        it mustBe Null
     }
 }
 
-fun isNotNull() {
+fun mustNotBeNull() {
     // given
     val obj = "test"
 
     // then
     obj mustSatisfy {
-        it isNot Null
+        it mustNotBe Null
     }
 }
 

--- a/lib/src/samples/kotlin/BooleanSamples.kt
+++ b/lib/src/samples/kotlin/BooleanSamples.kt
@@ -1,41 +1,41 @@
 package io.github.ccjhr.samples.boolean
 
-fun isTrue() {
+fun mustBeTrue() {
     // given
     val obj = true
 
     // then
     obj mustSatisfy {
-        it `is` true
+        it mustBe true
     }
 }
 
-fun isFalse() {
+fun mustBeFalse() {
     // given
     val obj = false
 
     // then
     obj mustSatisfy {
-        it `is` false
+        it mustBe false
     }
 }
 
-fun isNotTrue() {
+fun mustNotBeTrue() {
     // given
     val obj = false
 
     // then
     obj mustSatisfy {
-        it isNot true
+        it mustNotBe true
     }
 }
 
-fun isNotFalse() {
+fun mustNotBeFalse() {
     // given
     val obj = true
 
     // then
     obj mustSatisfy {
-        it isNot false
+        it mustNotBe false
     }
 }

--- a/lib/src/samples/kotlin/CharSequenceSamples.kt
+++ b/lib/src/samples/kotlin/CharSequenceSamples.kt
@@ -10,42 +10,42 @@ fun hasLength() {
     }
 }
 
-fun isNotEmpty() {
+fun mustNotBeEmpty() {
     // given
     val obj = "test"
 
     // then
     obj mustSatisfy {
-        it isNot Empty
+        it mustNotBe Empty
     }
 }
 
-fun isNotBlank() {
+fun mustNotBeBlank() {
     // given
     val obj = "test"
 
     // then
     obj mustSatisfy {
-        it isNot Blank
+        it mustNotBe Blank
     }
 }
 
-fun isBlank() {
+fun mustBeBlank() {
     // given
     val obj = "    "
 
     // then
     obj mustSatisfy {
-        it `is` Blank
+        it mustBe Blank
     }
 }
 
-fun isEmpty() {
+fun mustBeEmpty() {
     // given
     val obj = ""
 
     // then
     obj mustSatisfy {
-        it `is` Empty
+        it mustBe Empty
     }
 }

--- a/lib/src/samples/kotlin/DoubleSamples.kt
+++ b/lib/src/samples/kotlin/DoubleSamples.kt
@@ -20,83 +20,83 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustbeEven() {
     // given
     val obj = 12.0
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11.0
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11.0
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12.0
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 
-private fun isPositive() {
+private fun mustBePositive() {
     // given
     val obj = 12.0
 
     // then
     obj mustSatisfy {
-        it `is` Positive
+        it mustBe Positive
     }
 }
 
-private fun isNotPositive() {
+private fun mustNotBePositive() {
     // given
     val obj = -12.0
 
     // then
     obj mustSatisfy {
-        it isNot Positive
+        it mustNotBe Positive
     }
 }
 
-private fun isNegative() {
+private fun mustbeNegative() {
     // given
     val obj = -12.0
 
     // then
     obj mustSatisfy {
-        it `is` Negative
+        it mustBe Negative
     }
 }
 
-private fun isNotNegative() {
+private fun mustNotBeNegative() {
     // given
     val obj = 12.0
 
     // then
     obj mustSatisfy {
-        it isNot Negative
+        it mustNotBe Negative
     }
 }
 

--- a/lib/src/samples/kotlin/FloatSamples.kt
+++ b/lib/src/samples/kotlin/FloatSamples.kt
@@ -20,83 +20,83 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj = 12f
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11f
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11f
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12f
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 
-private fun isPositive() {
+private fun mustbePositive() {
     // given
     val obj = 12f
 
     // then
     obj mustSatisfy {
-        it `is` Positive
+        it mustBe Positive
     }
 }
 
-private fun isNotPositive() {
+private fun mustNotBePositive() {
     // given
     val obj = -12f
 
     // then
     obj mustSatisfy {
-        it isNot Positive
+        it mustNotBe Positive
     }
 }
 
-private fun isNegative() {
+private fun mustbeNegative() {
     // given
     val obj = -12f
 
     // then
     obj mustSatisfy {
-        it `is` Negative
+        it mustBe Negative
     }
 }
 
-private fun isNotNegative() {
+private fun mustNotBeNegative() {
     // given
     val obj = 12f
 
     // then
     obj mustSatisfy {
-        it isNot Negative
+        it mustNotBe Negative
     }
 }
 

--- a/lib/src/samples/kotlin/IntSamples.kt
+++ b/lib/src/samples/kotlin/IntSamples.kt
@@ -20,83 +20,83 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj = 12
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 
-private fun isPositive() {
+private fun mustbePositive() {
     // given
     val obj = 12
 
     // then
     obj mustSatisfy {
-        it `is` Positive
+        it mustBe Positive
     }
 }
 
-private fun isNotPositive() {
+private fun mustNotBePositive() {
     // given
     val obj = -12
 
     // then
     obj mustSatisfy {
-        it isNot Positive
+        it mustNotBe Positive
     }
 }
 
-private fun isNegative() {
+private fun mustbeNegative() {
     // given
     val obj = -12
 
     // then
     obj mustSatisfy {
-        it `is` Negative
+        it mustBe Negative
     }
 }
 
-private fun isNotNegative() {
+private fun mustNotBeNegative() {
     // given
     val obj = 12
 
     // then
     obj mustSatisfy {
-        it isNot Negative
+        it mustNotBe Negative
     }
 }
 

--- a/lib/src/samples/kotlin/LongSamples.kt
+++ b/lib/src/samples/kotlin/LongSamples.kt
@@ -20,83 +20,83 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj = 12L
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11L
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11L
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12L
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 
-private fun isPositive() {
+private fun mustbePositive() {
     // given
     val obj = 12L
 
     // then
     obj mustSatisfy {
-        it `is` Positive
+        it mustBe Positive
     }
 }
 
-private fun isNotPositive() {
+private fun mustNotBePositive() {
     // given
     val obj = -12L
 
     // then
     obj mustSatisfy {
-        it isNot Positive
+        it mustNotBe Positive
     }
 }
 
-private fun isNegative() {
+private fun mustbeNegative() {
     // given
     val obj = -12L
 
     // then
     obj mustSatisfy {
-        it `is` Negative
+        it mustBe Negative
     }
 }
 
-private fun isNotNegative() {
+private fun mustNotBeNegative() {
     // given
     val obj = 12L
 
     // then
     obj mustSatisfy {
-        it isNot Negative
+        it mustNotBe Negative
     }
 }
 

--- a/lib/src/samples/kotlin/ShortSamples.kt
+++ b/lib/src/samples/kotlin/ShortSamples.kt
@@ -20,83 +20,83 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj: Short = 12
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj: Short = 11
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj: Short = 11
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj: Short = 12
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 
-private fun isPositive() {
+private fun mustbePositive() {
     // given
     val obj: Short = 12
 
     // then
     obj mustSatisfy {
-        it `is` Positive
+        it mustBe Positive
     }
 }
 
-private fun isNotPositive() {
+private fun mustNotBePositive() {
     // given
     val obj: Short = -12
 
     // then
     obj mustSatisfy {
-        it isNot Positive
+        it mustNotBe Positive
     }
 }
 
-private fun isNegative() {
+private fun mustbeNegative() {
     // given
     val obj: Short = -12
 
     // then
     obj mustSatisfy {
-        it `is` Negative
+        it mustBe Negative
     }
 }
 
-private fun isNotNegative() {
+private fun mustNotBeNegative() {
     // given
     val obj: Short = 12
 
     // then
     obj mustSatisfy {
-        it isNot Negative
+        it mustNotBe Negative
     }
 }
 

--- a/lib/src/samples/kotlin/UIntSamples.kt
+++ b/lib/src/samples/kotlin/UIntSamples.kt
@@ -20,43 +20,43 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj = 12U
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11U
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11U
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12U
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 

--- a/lib/src/samples/kotlin/ULongSamples.kt
+++ b/lib/src/samples/kotlin/ULongSamples.kt
@@ -20,43 +20,43 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj = 12uL
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj = 11uL
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj = 11uL
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj = 12uL
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 

--- a/lib/src/samples/kotlin/UShortSamples.kt
+++ b/lib/src/samples/kotlin/UShortSamples.kt
@@ -20,43 +20,43 @@ private fun isLessThan() {
     }
 }
 
-private fun isEven() {
+private fun mustBeEven() {
     // given
     val obj: UShort = 12u
 
     // then
     obj mustSatisfy {
-        it `is` Even
+        it mustBe Even
     }
 }
 
-private fun isNotEven() {
+private fun mustNotBeEven() {
     // given
     val obj: UShort = 11u
 
     // then
     obj mustSatisfy {
-        it isNot Even
+        it mustNotBe Even
     }
 }
 
-private fun isOdd() {
+private fun mustBeOdd() {
     // given
     val obj: UShort = 11u
 
     // then
     obj mustSatisfy {
-        it `is` Odd
+        it mustBe Odd
     }
 }
 
-private fun isNotOdd() {
+private fun mustNotBeOdd() {
     // given
     val obj: UShort = 12u
 
     // then
     obj mustSatisfy {
-        it isNot Odd
+        it mustNotBe Odd
     }
 }
 

--- a/lib/src/test/kotlin/io/github/ccjhr/any/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/any/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Null
+                it mustBe Null
             }
         }
 
@@ -31,7 +31,7 @@ internal class IsKtTest {
 
         // when
         obj mustSatisfy {
-            it `is` Null
+            it mustBe Null
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/any/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/any/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Null
+                it mustNotBe Null
             }
         }
 
@@ -31,7 +31,7 @@ internal class IsNotKtTest {
 
         // when
         obj mustSatisfy {
-            it isNot Null
+            it mustNotBe Null
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/boolean/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/boolean/IsKtTest.kt
@@ -15,7 +15,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` false
+                it mustBe false
             }
         }
 
@@ -31,7 +31,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` false
+                it mustBe false
             }
         }
 
@@ -46,7 +46,7 @@ internal class IsKtTest {
 
         // when
         obj mustSatisfy {
-            it `is` true
+            it mustBe true
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/boolean/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/boolean/IsNotKtTest.kt
@@ -15,7 +15,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot false
+                it mustNotBe false
             }
         }
 
@@ -31,7 +31,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot false
+                it mustNotBe false
             }
         }
 
@@ -46,7 +46,7 @@ internal class IsNotKtTest {
 
         // when
         obj mustSatisfy {
-            it isNot true
+            it mustNotBe true
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/charsequence/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/charsequence/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Blank
+                it mustBe Blank
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Blank
+                    it mustBe Blank
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Blank
+                it mustBe Blank
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Empty
+                    it mustBe Empty
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Empty
+                it mustBe Empty
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/charsequence/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/charsequence/IsNotKtTest.kt
@@ -17,7 +17,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Blank
+                it mustNotBe Blank
             }
         }
 
@@ -35,7 +35,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Blank
+                    it mustNotBe Blank
                 }
             }
 
@@ -50,7 +50,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Blank
+                it mustNotBe Blank
             }
         }
     }
@@ -65,7 +65,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Empty
+                    it mustNotBe Empty
                 }
             }
 
@@ -80,7 +80,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Empty
+                it mustNotBe Empty
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/collection/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/collection/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Empty
+                it mustBe Empty
             }
         }
 
@@ -32,7 +32,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             list mustSatisfy {
-                it `is` Empty
+                it mustBe Empty
             }
         }
 
@@ -47,7 +47,7 @@ internal class IsKtTest {
 
         // when
         list mustSatisfy {
-            it `is` Empty
+            it mustBe Empty
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/collection/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/collection/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Empty
+                it mustNotBe Empty
             }
         }
 
@@ -32,7 +32,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             list mustSatisfy {
-                it isNot Empty
+                it mustNotBe Empty
             }
         }
 
@@ -47,7 +47,7 @@ internal class IsNotKtTest {
 
         // when
         list mustSatisfy {
-            it isNot Empty
+            it mustNotBe Empty
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/double/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/double/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Positive
+                    it mustBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Positive
+                it mustBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Negative
+                    it mustBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Negative
+                it mustBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/double/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/double/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Positive
+                    it mustNotBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Positive
+                it mustNotBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Negative
+                    it mustNotBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Negative
+                it mustNotBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/float/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/float/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Positive
+                    it mustBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Positive
+                it mustBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Negative
+                    it mustBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Negative
+                it mustBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/float/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/float/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Positive
+                    it mustNotBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Positive
+                it mustNotBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Negative
+                    it mustNotBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Negative
+                it mustNotBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/int/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/int/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Positive
+                    it mustBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Positive
+                it mustBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Negative
+                    it mustBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Negative
+                it mustBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/int/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/int/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Positive
+                    it mustNotBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Positive
+                it mustNotBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Negative
+                    it mustNotBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Negative
+                it mustNotBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/long/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/long/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Positive
+                    it mustBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Positive
+                it mustBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Negative
+                    it mustBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Negative
+                it mustBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/long/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/long/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Positive
+                    it mustNotBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Positive
+                it mustNotBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Negative
+                    it mustNotBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Negative
+                it mustNotBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/short/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/short/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Positive
+                    it mustBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Positive
+                it mustBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Negative
+                    it mustBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Negative
+                it mustBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/short/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/short/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }
@@ -94,7 +94,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Positive
+                    it mustNotBe Positive
                 }
             }
 
@@ -109,7 +109,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Positive
+                it mustNotBe Positive
             }
         }
     }
@@ -124,7 +124,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Negative
+                    it mustNotBe Negative
                 }
             }
 
@@ -139,7 +139,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Negative
+                it mustNotBe Negative
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/uint/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/uint/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/uint/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/uint/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/ulong/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/ulong/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustbe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustbe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustbe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustbe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustbe Even
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/ulong/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/ulong/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/ushort/IsKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/ushort/IsKtTest.kt
@@ -16,7 +16,7 @@ internal class IsKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Odd
+                    it mustBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Odd
+                it mustBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it `is` Even
+                    it mustBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsKtTest {
 
             // when
             obj mustSatisfy {
-                it `is` Even
+                it mustBe Even
             }
         }
     }

--- a/lib/src/test/kotlin/io/github/ccjhr/number/ushort/IsNotKtTest.kt
+++ b/lib/src/test/kotlin/io/github/ccjhr/number/ushort/IsNotKtTest.kt
@@ -16,7 +16,7 @@ internal class IsNotKtTest {
         // when
         val result = expectsException<AssertionError> {
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
 
@@ -34,7 +34,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Odd
+                    it mustNotBe Odd
                 }
             }
 
@@ -49,7 +49,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Odd
+                it mustNotBe Odd
             }
         }
     }
@@ -64,7 +64,7 @@ internal class IsNotKtTest {
             // when
             val result = expectsException<AssertionError> {
                 obj mustSatisfy {
-                    it isNot Even
+                    it mustNotBe Even
                 }
             }
 
@@ -79,7 +79,7 @@ internal class IsNotKtTest {
 
             // when
             obj mustSatisfy {
-                it isNot Even
+                it mustNotBe Even
             }
         }
     }


### PR DESCRIPTION
…d of escaping for the is operator